### PR TITLE
convert BGR to RGB in EpicKitchens

### DIFF
--- a/base/base_dataset.py
+++ b/base/base_dataset.py
@@ -303,7 +303,8 @@ def read_frames_cv2_epic(video_path, start_frame, stop_frame, num_frames, sample
     success_idxs = []
     for index in frame_idxs:
         img_name = 'frame_' + str(index).zfill(10) + '.jpg'
-        frame = cv2.imread(os.path.join(video_path, img_name),cv2.COLOR_BGR2RGB)
+        frame = cv2.imread(os.path.join(video_path, img_name))
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
         frame = torch.from_numpy(frame)
         # (H x W x C) to (C x H x W)


### PR DESCRIPTION
The BGR2RGB conversion is done incorrectly in the current Epic-Kitchens dataloader. 
cv2.imread() does not take cv2.COLOR_BGR2RGB as flag [[official docs](https://docs.opencv.org/4.x/d4/da8/group__imgcodecs.html#ga288b8b3da0892bd651fce07b3bbd3a56)], the conversion need to be done separately with cv2.cvtColor().

Fixing the color channels leads to a much higher results in the zero-shot EK-MIR task: mAP=22.2 mDCG=26.9.